### PR TITLE
Update MSPAR(36) if required size of MTREES array is reduced

### DIFF
--- a/src/SPR/sprtrs.f
+++ b/src/SPR/sprtrs.f
@@ -521,6 +521,9 @@ C     ---------------
       MSPAR(19) = NELACT
       MSPAR(20) = LCOEFA
       MSPAR(25) = ELSIZE
+      IF ( MTUSED .LT. NTREES+1 ) THEN
+         MSPAR(36) = MTUSED - 1
+      ENDIF
 
 * --- New quantities to control superelement technique.
       IF ( NSPAR .GT. 50 ) THEN


### PR DESCRIPTION
The estimated size of the MTREES array (calculated in SPRSEN and stored in MSPAR(36)) is sometimes too large, resulting in some (harmless, but still) uninitialized values at the end of the array. Therefore, the MSPAR(36) value is updated to the actual length when MTREES is finished, such that the caller can take proper action.